### PR TITLE
fix(pls): prepare upload database for QALI locality gaps

### DIFF
--- a/address_etl/pls/queries/local_auth.py
+++ b/address_etl/pls/queries/local_auth.py
@@ -24,6 +24,8 @@ def get_query():
                     sdo:propertyID "pndb.lga_name" ;
                     sdo:value ?lga_name
                 ]
+
+                FILTER(STRLEN(STR(?lga_name)) > 0)
             }
         }
         """

--- a/address_etl/pls/queries/locality.py
+++ b/address_etl/pls/queries/locality.py
@@ -38,8 +38,13 @@ def get_query():
                 ],
                 [
                     sdo:propertyID "pndb.status" ;
-                    sdo:value ?status
+                    sdo:value ?_status
                 ]
+
+                # Some unofficial QALI localities do not exist in PNDB, so their
+                # PNDB fields are empty strings. Treat blank PNDB status as
+                # current for PLS.
+                BIND(IF(STR(?_status) = "", "Y", ?_status) AS ?status)
             }
         }
 

--- a/address_etl/pls/tables.py
+++ b/address_etl/pls/tables.py
@@ -467,10 +467,15 @@ def validate_foreign_keys(cursor: sqlite3.Cursor) -> None:
         formatted_violations = "; ".join(
             _format_foreign_key_violation(violation) for violation in violations
         )
-        raise RuntimeError(
-            "SQLite foreign key check failed before upload; "
-            f"first {len(violations)} violation(s): {formatted_violations}"
+        logger.warning(
+            "SQLite foreign key check found violations before upload; "
+            "first %s violation(s): %s",
+            len(violations),
+            formatted_violations,
         )
+        return
+
+    logger.info("SQLite foreign key check passed before upload")
 
 
 def populate_parcel_tables(client: httpx.Client, cursor: sqlite3.Cursor):
@@ -874,7 +879,4 @@ def populate_tables(cursor: sqlite3.Cursor):
     text_to_id_for_pk("lf_site_id_map", "lf_site", "site_id", cursor)
     text_to_id_for_pk("lf_place_name_id_map", "lf_place_name", "place_name_id", cursor)
     text_to_id_for_pk("lf_address_id_map", "lf_address", "addr_id", cursor)
-    # Temporarily disabled: the SQLite schema currently enforces some foreign keys
-    # that are stricter than the PLS definitions, so valid source data can fail
-    # before upload until those schema/definition mismatches are resolved.
-    # validate_foreign_keys(cursor)
+    validate_foreign_keys(cursor)

--- a/main_pls.py
+++ b/main_pls.py
@@ -89,6 +89,26 @@ def load_previous_esri_geocodes(cursor: sqlite3.Cursor) -> bool:
     return True
 
 
+def compact_sqlite_database(db_path: str) -> None:
+    logger.info("Compacting SQLite database before upload")
+    start_time = time.time()
+    before_size = Path(db_path).stat().st_size
+
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute("VACUUM")
+    finally:
+        connection.close()
+
+    after_size = Path(db_path).stat().st_size
+    logger.info(
+        "Compacted SQLite database in %.2f seconds; size changed from %.2f MiB to %.2f MiB",
+        time.time() - start_time,
+        before_size / 1024 / 1024,
+        after_size / 1024 / 1024,
+    )
+
+
 def main():
     logging.basicConfig(
         level=logging.INFO,
@@ -220,6 +240,7 @@ def main():
             logger.info("Closing connection to SQLite database before upload")
             connection.close()
             connection = None
+            compact_sqlite_database(settings.pls_sqlite_conn_str)
 
             s3_key = f"{S3_FILE_PREFIX_KEY}{etl_finished_at_str}/pls.db"
             presigned_url = upload_file(

--- a/tests/test_address_query_templates.py
+++ b/tests/test_address_query_templates.py
@@ -1,5 +1,5 @@
 from address_etl.pls.debug_parcels import DEBUG_PARCEL_IRIS
-from address_etl.pls.queries import address
+from address_etl.pls.queries import address, local_auth, locality
 
 
 def test_get_query_iris_only_filters_to_current_non_private_addresses():
@@ -40,6 +40,20 @@ def test_get_query_filters_to_current_non_private_addresses():
     assert "GRAPH <urn:qali:graph:tags>" in query
     assert "<urn:qali:tag-collection:private> skos:member ?private_tag ." in query
     assert "?address_pid" not in query
+
+
+def test_local_auth_query_excludes_empty_lga_names():
+    query = local_auth.get_query()
+
+    assert "FILTER(STRLEN(STR(?lga_name)) > 0)" in query
+
+
+def test_locality_query_maps_empty_statuses_to_current():
+    query = locality.get_query()
+
+    assert "sdo:value ?_status" in query
+    assert 'BIND(IF(STR(?_status) = "", "Y", ?_status) AS ?status)' in query
+    assert "FILTER(STRLEN(STR(?status)) = 1)" not in query
 
 
 def test_debug_parcel_iris_list_has_expected_size():

--- a/tests/test_main_pls_kafka.py
+++ b/tests/test_main_pls_kafka.py
@@ -64,6 +64,10 @@ def test_main_publishes_uploaded_presigned_url_to_kafka(
         events.append("metadata_end")
         recorded["metadata_end"] = end_time_str
 
+    def fake_compact_sqlite_database(file_path):
+        events.append("compact")
+        assert file_path == str(tmp_path / "pls.db")
+
     def fake_upload_file(bucket_name, key, file_path, s3, presigned_url_expiry_seconds):
         events.append("upload")
         recorded["upload"] = {
@@ -87,6 +91,9 @@ def test_main_publishes_uploaded_presigned_url_to_kafka(
     )
     monkeypatch.setattr(
         main_pls, "metadata_write_end_time", fake_metadata_write_end_time
+    )
+    monkeypatch.setattr(
+        main_pls, "compact_sqlite_database", fake_compact_sqlite_database
     )
     monkeypatch.setattr(main_pls, "upload_file", fake_upload_file)
     monkeypatch.setattr(main_pls, "publish_presigned_url", fake_publish_presigned_url)
@@ -118,7 +125,7 @@ def test_main_publishes_uploaded_presigned_url_to_kafka(
 
     assert recorded["metadata_start"] == "2026-04-23T02:00:00+0000"
     assert recorded["metadata_end"] == "2026-04-23T02:02:30+0000"
-    assert events == ["metadata_end", "upload"]
+    assert events == ["metadata_end", "compact", "upload"]
     assert recorded["upload"] == {
         "bucket_name": "pls-feature-service-etl",
         "key": "pls-etl/2026-04-23T02:02:30+0000/pls.db",
@@ -170,6 +177,7 @@ def test_main_skips_kafka_publish_when_disabled(
     monkeypatch.setattr(main_pls, "utc_to_brisbane_time", lambda dt: dt)
     monkeypatch.setattr(main_pls, "metadata_write_start_time", lambda *args: None)
     monkeypatch.setattr(main_pls, "metadata_write_end_time", lambda *args: None)
+    monkeypatch.setattr(main_pls, "compact_sqlite_database", lambda *args: None)
     monkeypatch.setattr(main_pls, "upload_file", fake_upload_file)
     monkeypatch.setattr(main_pls, "publish_presigned_url", fake_publish_presigned_url)
     monkeypatch.setattr(main_pls, "get_latest_file", lambda *args, **kwargs: None)
@@ -245,6 +253,9 @@ def test_main_closes_sqlite_before_uploading_wal_database(monkeypatch, tmp_path)
     monkeypatch.setattr(main_pls, "utc_to_brisbane_time", lambda dt: dt)
     monkeypatch.setattr(main_pls, "metadata_write_start_time", lambda *args: None)
     monkeypatch.setattr(main_pls, "metadata_write_end_time", lambda *args: None)
+    monkeypatch.setattr(
+        main_pls, "compact_sqlite_database", main_pls.compact_sqlite_database
+    )
     monkeypatch.setattr(main_pls, "upload_file", fake_upload_file)
     monkeypatch.setattr(main_pls, "publish_presigned_url", lambda *args: None)
     monkeypatch.setattr(main_pls, "get_latest_file", lambda *args, **kwargs: None)
@@ -277,6 +288,40 @@ def test_main_closes_sqlite_before_uploading_wal_database(monkeypatch, tmp_path)
         "uploaded_count": 5000,
         "wal_exists_at_upload": False,
     }
+
+
+def test_compact_sqlite_database_vacuums_in_place(tmp_path):
+    db_path = tmp_path / "pls.db"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute("CREATE TABLE records (value TEXT)")
+        connection.executemany(
+            "INSERT INTO records (value) VALUES (?)",
+            [("x" * 1000,) for _ in range(5000)],
+        )
+        connection.commit()
+        connection.execute("DELETE FROM records")
+        connection.commit()
+    finally:
+        connection.close()
+
+    size_before = db_path.stat().st_size
+
+    main_pls.compact_sqlite_database(str(db_path))
+
+    size_after = db_path.stat().st_size
+    compacted_connection = sqlite3.connect(db_path)
+    try:
+        assert (
+            compacted_connection.execute("PRAGMA quick_check(1)").fetchone()[0] == "ok"
+        )
+        assert (
+            compacted_connection.execute("SELECT COUNT(*) FROM records").fetchone()[0]
+            == 0
+        )
+    finally:
+        compacted_connection.close()
+    assert size_after < size_before
 
 
 def test_load_previous_esri_geocodes_skips_legacy_pls_geocode_table(tmp_path):

--- a/tests/test_pls_address_pid_flow.py
+++ b/tests/test_pls_address_pid_flow.py
@@ -30,7 +30,7 @@ def connection_with_foreign_keys():
     return db
 
 
-def test_validate_foreign_keys_rejects_existing_violations_after_reenable():
+def test_validate_foreign_keys_logs_existing_violations_after_reenable(caplog):
     db = connection()
     try:
         cursor = db.cursor()
@@ -80,10 +80,11 @@ def test_validate_foreign_keys_rejects_existing_violations_after_reenable():
         )
         db.commit()
 
-        with pytest.raises(RuntimeError, match="SQLite foreign key check failed"):
-            validate_foreign_keys(cursor)
+        validate_foreign_keys(cursor)
 
         assert cursor.execute("PRAGMA foreign_keys").fetchone()["foreign_keys"] == 1
+        assert "SQLite foreign key check found violations before upload" in caplog.text
+        assert "table=lf_address" in caplog.text
     finally:
         db.close()
 


### PR DESCRIPTION
Filter empty LGA names from the local authority query and treat blank PNDB locality statuses as current so unofficial QALI localities can flow into PLS.

Run SQLite foreign key checks before upload without blocking on known schema mismatches, and log the first violations for follow-up diagnostics.

Compact the closed SQLite database with VACUUM before uploading so the published artifact excludes reclaimable pages and finalized WAL content.

Tests cover the query template changes, foreign-key warning behavior, pre-upload compaction order, and in-place VACUUM integrity.